### PR TITLE
fix: set auto2top true and fix logo link

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,9 +14,10 @@
     window.$docsify = {
       repo: 'stacksgov/pm',
       subMaxLevel: 3,
-      logo: 'https://github.com/stacksgov/resources/blob/master/brand/stacksgov_greensquare_150x150.png',
+      logo: 'https://github.com/stacksgov/resources/blob/master/brand/stacksgov_greensquare_150x150.png?raw=true',
       name: 'Stacksgov Community Governance Project Management',
-      relativePath: true
+      relativePath: true,
+      auto2top: true
     }
   </script>
   <script src="//cdn.jsdelivr.net/npm/docsify/lib/docsify.min.js"></script>


### PR DESCRIPTION
This is a quick PR to add a setting that auto-scrolls to the top of each page, and more improtantly, adds `?raw=true` to the end of the image tag for the logo (which was broken). It's always the little things!