### PR TITLE
Update meeting agenda issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-mtg-agenda.md
+++ b/.github/ISSUE_TEMPLATE/1-mtg-agenda.md
@@ -10,8 +10,6 @@ labels: mtg-agenda
 - **Date/Time:** Month Date, Year @ 4:00pm UTC / 12:00pm ET
 - **Location:** Link will be posted in the `#governance` working group channel [on Discord](https://community.blockstack.org/discord) shortly before the call.
 - **Moderator:** TBA
-- **Secretary:** TBA
-- **Publisher:** TBA
 
 The [Stacks Governance - Calls](https://stacksgov.github.io/resources/#/calls/?id=governance-working-group) page contains a table of past calls, including a link to the agenda, recording, notes, and resources.
 

--- a/.github/ISSUE_TEMPLATE/1-mtg-agenda.md
+++ b/.github/ISSUE_TEMPLATE/1-mtg-agenda.md
@@ -9,10 +9,11 @@ labels: mtg-agenda
 
 - **Date/Time:** Month Date, Year @ 4:00pm UTC / 12:00pm ET
 - **Location:** Link will be posted in the `#governance` working group channel [on Discord](https://community.blockstack.org/discord) shortly before the call.
-- **Recording:** TBA
 - **Moderator:** TBA
 - **Secretary:** TBA
 - **Publisher:** TBA
+
+The [Stacks Governance - Calls](https://stacksgov.github.io/resources/#/calls/?id=governance-working-group) page contains a table of past calls, including a link to the agenda, recording, notes, and resources.
 
 ## Standup Updates
 


### PR DESCRIPTION
This PR removes the recording link from individual issues and adds a link to the governance working group calls table from the resources repository instead. In the spirit of trying to keep things simple, it would be better to have the data updated on the table then to worry about coming back to the agenda issue and updating the link.

This PR also removes the meeting secretary/publisher from the list of meeting roles. The roles still exist (and are encouraged!), but with no direct implementation of #80 or #81 yet, this ends up being extra, stale data (always TBA).