### PR TITLE
add stale bot config

### DIFF
--- a/.github/ISSUE_TEMPLATE/stale.yml
+++ b/.github/ISSUE_TEMPLATE/stale.yml
@@ -1,0 +1,17 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 14
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+# Label to use when marking an issue as stale
+staleLabel: stale-issue
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
This sets up a bot that will label an issue as `stale-issue` after 14 days of no activity, and close the issue automatically if it stays inactive for another 7 days.

Stale issues can be reopened by anyone who wants to revive the topic.